### PR TITLE
Remove DrawFlag and add buffer to reduce flickering

### DIFF
--- a/HJM.Chip8/HJM.Chip8.CPU/Chip8.cs
+++ b/HJM.Chip8/HJM.Chip8.CPU/Chip8.cs
@@ -10,10 +10,6 @@ namespace HJM.Chip8.CPU
     public class Chip8
     {
         /// <summary>
-        /// Whether the screen needs to be drawn or not
-        /// </summary>
-        public bool DrawFlag { get; set; }
-        /// <summary>
         /// Whether sound should be played or not 
         /// </summary>
         public bool SoundFlag { get; set; }
@@ -118,7 +114,6 @@ namespace HJM.Chip8.CPU
                         case 0x00E0: //  00E0 - CLS
                                      //  Clear the display.
                             Graphics = new byte[64 * 32];
-                            DrawFlag = true;
                             ProgramCounter += 2;
                             break;
 
@@ -359,7 +354,6 @@ namespace HJM.Chip8.CPU
                         }
                     }
 
-                    DrawFlag = true;
                     ProgramCounter += 2;
                     break;
 


### PR DESCRIPTION
Here's a fix for #11 

I've implemented a display buffer, which can store the contents of up to 8 previous frames in an array the same size as the graphics array.
It uses bitshifting and bitmasks to stay light in memory usage, while allowing for easier or 'live' customisation over the amount of buffered frames.
This can completely remove flickering, but setting the value too high can cause ghosting.
I've found three-four buffered frames to be a decent 'goldilocks' number, but your mileage may vary.

This will result in more gpu draws, but I personally think it's a fair comprimise over the flickering.

Let me know if there's anything that needs changing, or if you have any issues with this.